### PR TITLE
Update nunit dependencies and target .NET 8

### DIFF
--- a/Templates/C#/SolutionTemplate/Project.Test/Project.Test.csproj
+++ b/Templates/C#/SolutionTemplate/Project.Test/Project.Test.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Templates/C#/SolutionTemplate/Project/Project.csproj
+++ b/Templates/C#/SolutionTemplate/Project/Project.csproj
@@ -2,12 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Project</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Ran into issues trying to use the current C# template during tonight's C3. This PR is intended to address those issues:

* netcoreapp3.1 is no longer supported, and SDK is not installed by default with VS 2022
* nunit dependencies were out-of-date